### PR TITLE
This commit adds small fixes around the execution of the service after the restructuring.

### DIFF
--- a/collection.http
+++ b/collection.http
@@ -1,0 +1,17 @@
+@name = Yonatan
+
+### Greeting Api - Hello
+GET http://localhost:8080/hello/{{name}}
+Content-Type: application/json
+
+### Greeting Api - Goodbye
+GET http://localhost:8080/goodbye/{{name}}
+Content-Type: application/json
+
+### Hello Api
+GET http://localhost:8181/hello/{{name}}
+Content-Type: application/json
+
+### Goodbye Api
+GET http://localhost:8282/goodbye/{{name}}
+Content-Type: application/json

--- a/domain-gateway/build.gradle.kts
+++ b/domain-gateway/build.gradle.kts
@@ -19,7 +19,7 @@ dependencies {
     implementation(libs.bundles.springboot.all)
 
     api(libs.bundles.retrofit.all)
-    compileOnly(libs.retrofit2.scalars)
+    implementation(libs.retrofit2.scalars)
 
     testImplementation(libs.bundles.tests.all)
 }
@@ -101,6 +101,7 @@ val supportedApis = listOf(
         name = "Hello API",
         taskName = "generateHelloApi",
         directoryPath = apiDirectoryPath,
+        templateDir = "$apiDirectoryPath/templates/kotlin-client",
         outputDir = "$openApiGenerateOutputDir/domain-gateway",
         specFileName = "hello-api.yaml",
         generatorType = "kotlin",
@@ -122,6 +123,7 @@ val supportedApis = listOf(
         name = "Goodbye API",
         taskName = "generateGoodbyeApi",
         directoryPath = apiDirectoryPath,
+        templateDir = "$apiDirectoryPath/templates/kotlin-client",
         outputDir = "$openApiGenerateOutputDir/domain-gateway",
         specFileName = "goodbye-api.yaml",
         generatorType = "kotlin",

--- a/domain-gateway/src/main/kotlin/com/yonatankarp/domain/gateway/config/DomainGatewayConfig.kt
+++ b/domain-gateway/src/main/kotlin/com/yonatankarp/domain/gateway/config/DomainGatewayConfig.kt
@@ -10,8 +10,6 @@ import org.openapitools.client.infrastructure.ApiClient
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
-import retrofit2.Converter.Factory
-import retrofit2.converter.jackson.JacksonConverterFactory
 
 /**
  * Configuration class for setting up API clients and related components in the
@@ -48,50 +46,30 @@ class DomainGatewayConfig(
             )
 
     /**
-     * Provides a [JacksonConverterFactory] bean for JSON serialization and
-     * deserialization.
-     *
-     * @param objectMapper The ObjectMapper bean provided by Spring.
-     * @return JacksonConverterFactory configured with the provided ObjectMapper.
-     */
-    @Bean
-    fun jacksonConverterFactory(objectMapper: ObjectMapper): JacksonConverterFactory = JacksonConverterFactory.create(objectMapper)
-
-    /**
      * Provides an API client for the Hello Service.
      *
      * @param objectMapper The ObjectMapper bean provided by Spring.
-     * @param converterFactories List of Retrofit Converter Factories.
      * @return An instance of [HelloApi] created with the specified configurations.
      */
     @Bean
-    fun helloApiClient(
-        objectMapper: ObjectMapper,
-        converterFactories: List<Factory>,
-    ): HelloApi =
+    fun helloApiClient(objectMapper: ObjectMapper): HelloApi =
         ApiClient(
             baseUrl = helloServiceBaseURL,
             serializerBuilder = objectMapper,
             okHttpClientBuilder = okHttpClientBuilder(),
-            converterFactories = converterFactories,
         ).createService(HelloApi::class.java)
 
     /**
      * Provides an API client for the Goodbye Service.
      *
      * @param objectMapper The ObjectMapper bean provided by Spring.
-     * @param converterFactories List of Retrofit Converter Factories.
      * @return An instance of [GoodbyeApi] created with the specified configurations.
      */
     @Bean
-    fun goodbyeApiClient(
-        objectMapper: ObjectMapper,
-        converterFactories: List<Factory>,
-    ): GoodbyeApi =
+    fun goodbyeApiClient(objectMapper: ObjectMapper): GoodbyeApi =
         ApiClient(
             baseUrl = goodbyeServiceBaseURL,
             serializerBuilder = objectMapper,
             okHttpClientBuilder = okHttpClientBuilder(),
-            converterFactories = converterFactories,
         ).createService(GoodbyeApi::class.java)
 }

--- a/domain-gateway/src/main/kotlin/com/yonatankarp/domain/gateway/controllers/mappers/GoodbyeMapper.kt
+++ b/domain-gateway/src/main/kotlin/com/yonatankarp/domain/gateway/controllers/mappers/GoodbyeMapper.kt
@@ -13,7 +13,6 @@ object GoodbyeMapper {
     /**
      * Maps a response from the Goodbye Service to an HTTP response entity.
      *
-     * @param response The response from the Goodbye Service as a receiver.
      * @return A ResponseEntity containing the mapped response.
      */
     fun Response<GoodbyeServiceResponse>.toResponse(): ResponseEntity<Any> =

--- a/domain-gateway/src/main/kotlin/com/yonatankarp/domain/gateway/controllers/mappers/HelloMapper.kt
+++ b/domain-gateway/src/main/kotlin/com/yonatankarp/domain/gateway/controllers/mappers/HelloMapper.kt
@@ -13,7 +13,6 @@ object HelloMapper {
     /**
      * Maps a response from the Hello Server to an HTTP response entity.
      *
-     * @param response The response from the Hello Server as a receiver.
      * @return A ResponseEntity containing the mapped response.
      */
     fun Response<HelloServerResponse>.toResponse(): ResponseEntity<Any> =

--- a/domain-gateway/src/main/resources/api/templates/kotlin-client/libraries/jvm-retrofit2/infrastructure/ApiClient.kt.mustache
+++ b/domain-gateway/src/main/resources/api/templates/kotlin-client/libraries/jvm-retrofit2/infrastructure/ApiClient.kt.mustache
@@ -1,0 +1,358 @@
+package {{packageName}}.infrastructure
+
+{{#hasOAuthMethods}}
+import org.apache.oltu.oauth2.client.request.OAuthClientRequest.AuthenticationRequestBuilder
+import org.apache.oltu.oauth2.client.request.OAuthClientRequest.TokenRequestBuilder
+import {{packageName}}.auth.OAuth
+import {{packageName}}.auth.OAuth.AccessTokenListener
+import {{packageName}}.auth.OAuthFlow
+{{/hasOAuthMethods}}
+{{#hasAuthMethods}}
+{{#authMethods}}
+{{#isBasic}}
+{{#isBasicBasic}}
+import {{packageName}}.auth.HttpBasicAuth
+{{/isBasicBasic}}
+{{#isBasicBearer}}
+import {{packageName}}.auth.HttpBearerAuth
+{{/isBasicBearer}}
+{{/isBasic}}
+{{#isApiKey}}
+import {{packageName}}.auth.ApiKeyAuth
+{{/isApiKey}}
+{{/authMethods}}
+{{/hasAuthMethods}}
+
+import okhttp3.Call
+import okhttp3.Interceptor
+import okhttp3.OkHttpClient
+import retrofit2.Retrofit
+import okhttp3.logging.HttpLoggingInterceptor
+import retrofit2.Converter
+import retrofit2.CallAdapter
+import retrofit2.converter.scalars.ScalarsConverterFactory
+{{#useRxJava}}
+import retrofit2.adapter.rxjava.RxJavaCallAdapterFactory
+{{/useRxJava}}
+{{#useRxJava2}}
+import retrofit2.adapter.rxjava2.RxJava2CallAdapterFactory
+{{/useRxJava2}}
+{{#useRxJava3}}
+import retrofit2.adapter.rxjava3.RxJava3CallAdapterFactory
+{{/useRxJava3}}
+{{#gson}}
+import com.google.gson.Gson
+import com.google.gson.GsonBuilder
+import retrofit2.converter.gson.GsonConverterFactory
+{{/gson}}
+{{#moshi}}
+import com.squareup.moshi.Moshi
+import retrofit2.converter.moshi.MoshiConverterFactory
+{{/moshi}}
+{{#jackson}}
+import com.fasterxml.jackson.databind.ObjectMapper
+import retrofit2.converter.jackson.JacksonConverterFactory
+{{/jackson}}
+
+{{#kotlinx_serialization}}
+import com.jakewharton.retrofit2.converter.kotlinx.serialization.asConverterFactory
+import {{packageName}}.infrastructure.Serializer.kotlinxSerializationJson
+import okhttp3.MediaType.Companion.toMediaType
+{{/kotlinx_serialization}}
+
+{{#nonPublicApi}}internal {{/nonPublicApi}}class ApiClient(
+    private var baseUrl: String = defaultBasePath,
+    private val okHttpClientBuilder: OkHttpClient.Builder? = null,
+    {{^kotlinx_serialization}}
+    private val serializerBuilder: {{#gson}}GsonBuilder{{/gson}}{{#moshi}}Moshi.Builder{{/moshi}}{{#jackson}}ObjectMapper{{/jackson}} = Serializer.{{#gson}}gsonBuilder{{/gson}}{{#moshi}}moshiBuilder{{/moshi}}{{#jackson}}jacksonObjectMapper{{/jackson}},
+    {{/kotlinx_serialization}}
+    private val callFactory : Call.Factory? = null,
+    private val callAdapterFactories: List<CallAdapter.Factory> = listOf(
+        {{#useRxJava}}
+        RxJavaCallAdapterFactory.create(),
+        {{/useRxJava}}
+        {{#useRxJava2}}
+        RxJava2CallAdapterFactory.create(),
+        {{/useRxJava2}}
+        {{#useRxJava3}}
+        RxJava3CallAdapterFactory.create(),
+        {{/useRxJava3}}
+    ),
+    private val converterFactories: List<Converter.Factory> = listOf(
+        ScalarsConverterFactory.create(),
+        {{#gson}}
+        GsonConverterFactory.create(serializerBuilder.create()),
+        {{/gson}}
+        {{#moshi}}
+        MoshiConverterFactory.create(serializerBuilder.build()),
+        {{/moshi}}
+        {{#kotlinx_serialization}}
+        kotlinxSerializationJson.asConverterFactory("application/json".toMediaType()),
+        {{/kotlinx_serialization}}
+        {{#jackson}}
+        JacksonConverterFactory.create(serializerBuilder),
+        {{/jackson}}
+    )
+) {
+    private val apiAuthorizations = mutableMapOf<String, Interceptor>()
+    var logger: ((String) -> Unit)? = null
+
+    private val retrofitBuilder: Retrofit.Builder by lazy {
+        Retrofit.Builder()
+            .baseUrl(baseUrl)
+            .apply {
+                callAdapterFactories.forEach {
+                    addCallAdapterFactory(it)
+                }
+            }
+            .apply {
+                converterFactories.forEach {
+                    addConverterFactory(it)
+                }
+            }
+    }
+
+    private val clientBuilder: OkHttpClient.Builder by lazy {
+        okHttpClientBuilder ?: defaultClientBuilder
+    }
+
+    private val defaultClientBuilder: OkHttpClient.Builder by lazy {
+        OkHttpClient()
+            .newBuilder()
+            .addInterceptor(HttpLoggingInterceptor { message -> logger?.invoke(message) }
+                .apply { level = HttpLoggingInterceptor.Level.BODY }
+            )
+    }
+
+    init {
+        normalizeBaseUrl()
+    }
+
+    {{#hasAuthMethods}}
+    constructor(
+        baseUrl: String = defaultBasePath,
+        okHttpClientBuilder: OkHttpClient.Builder? = null,
+        {{^kotlinx_serialization}}serializerBuilder: {{#gson}}GsonBuilder{{/gson}}{{#moshi}}Moshi.Builder{{/moshi}}{{#jackson}}ObjectMapper{{/jackson}} = Serializer.{{#gson}}gsonBuilder{{/gson}}{{#moshi}}moshiBuilder{{/moshi}}{{#jackson}}jacksonObjectMapper{{/jackson}},{{/kotlinx_serialization}}
+        authNames: Array<String>
+    ) : this(baseUrl, okHttpClientBuilder{{^kotlinx_serialization}}, serializerBuilder{{/kotlinx_serialization}}) {
+        authNames.forEach { authName ->
+            val auth: Interceptor? = when (authName) { {{#authMethods}}
+                {{#isBasicBasic}}"{{name}}" -> HttpBasicAuth()
+                {{/isBasicBasic}}{{#isBasicBearer}}"{{name}}" -> HttpBearerAuth("{{scheme}}")
+                {{/isBasicBearer}}{{#isApiKey}}"{{name}}" -> ApiKeyAuth({{#isKeyInHeader}}"header"{{/isKeyInHeader}}{{#isKeyInQuery}}"query"{{/isKeyInQuery}}{{#isKeyInCookie}}"cookie"{{/isKeyInCookie}}, "{{keyParamName}}")
+                {{/isApiKey}}{{#isOAuth}}"{{name}}" -> OAuth(OAuthFlow.{{flow}}, "{{authorizationUrl}}", "{{tokenUrl}}", "{{#scopes}}{{scope}}{{^-last}}, {{/-last}}{{/scopes}}")
+                {{/isOAuth}}{{^isBasicBasic}}{{^isBasicBearer}}{{^isApiKey}}{{^isOAuth}}"{{name}}" -> null{{/isOAuth}}{{/isApiKey}}{{/isBasicBearer}}{{/isBasicBasic}}{{/authMethods}}
+                else -> throw RuntimeException("auth name $authName not found in available auth names")
+            }
+            if (auth != null) {
+                addAuthorization(authName, auth)
+            }
+        }
+    }
+
+    {{#authMethods}}
+    {{#isBasic}}
+    {{#isBasicBasic}}
+    constructor(
+        baseUrl: String = defaultBasePath,
+        okHttpClientBuilder: OkHttpClient.Builder? = null,
+        {{^kotlinx_serialization}}serializerBuilder: {{#gson}}GsonBuilder{{/gson}}{{#moshi}}Moshi.Builder{{/moshi}}{{#jackson}}ObjectMapper{{/jackson}} = Serializer.{{#gson}}gsonBuilder{{/gson}}{{#moshi}}moshiBuilder{{/moshi}}{{#jackson}}jacksonObjectMapper{{/jackson}},{{/kotlinx_serialization}}
+        authName: String,
+        username: String,
+        password: String
+    ) : this(baseUrl, okHttpClientBuilder, {{^kotlinx_serialization}}serializerBuilder, {{/kotlinx_serialization}}arrayOf(authName)) {
+        setCredentials(username, password)
+    }
+
+    {{/isBasicBasic}}
+    {{#isBasicBearer}}
+    constructor(
+        baseUrl: String = defaultBasePath,
+        okHttpClientBuilder: OkHttpClient.Builder? = null,
+        {{^kotlinx_serialization}}serializerBuilder: {{#gson}}GsonBuilder{{/gson}}{{#moshi}}Moshi.Builder{{/moshi}}{{#jackson}}ObjectMapper{{/jackson}} = Serializer.{{#gson}}gsonBuilder{{/gson}}{{#moshi}}moshiBuilder{{/moshi}}{{#jackson}}jacksonObjectMapper{{/jackson}},{{/kotlinx_serialization}}
+        authName: String,
+        bearerToken: String
+    ) : this(baseUrl, okHttpClientBuilder, {{^kotlinx_serialization}}serializerBuilder, {{/kotlinx_serialization}}arrayOf(authName)) {
+        setBearerToken(bearerToken)
+    }
+
+    {{/isBasicBearer}}
+    {{/isBasic}}
+    {{/authMethods}}
+    {{#hasOAuthMethods}}
+    constructor(
+        baseUrl: String = defaultBasePath,
+        okHttpClientBuilder: OkHttpClient.Builder? = null,
+        {{^kotlinx_serialization}}serializerBuilder: {{#gson}}GsonBuilder{{/gson}}{{#moshi}}Moshi.Builder{{/moshi}}{{#jackson}}ObjectMapper{{/jackson}} = Serializer.{{#gson}}gsonBuilder{{/gson}}{{#moshi}}moshiBuilder{{/moshi}}{{#jackson}}jacksonObjectMapper{{/jackson}},{{/kotlinx_serialization}}
+        authName: String,
+        clientId: String,
+        secret: String,
+        username: String,
+        password: String
+    ) : this(baseUrl, okHttpClientBuilder, {{^kotlinx_serialization}}serializerBuilder, {{/kotlinx_serialization}}arrayOf(authName)) {
+        getTokenEndPoint()
+            ?.setClientId(clientId)
+            ?.setClientSecret(secret)
+            ?.setUsername(username)
+            ?.setPassword(password)
+    }
+
+    {{/hasOAuthMethods}}
+    {{#authMethods}}
+    {{#isBasic}}
+    {{#isBasicBasic}}
+    fun setCredentials(username: String, password: String): ApiClient {
+        apiAuthorizations.values.runOnFirst<Interceptor, HttpBasicAuth> {
+            setCredentials(username, password)
+        }
+        {{#hasOAuthMethods}}
+        apiAuthorizations.values.runOnFirst<Interceptor, OAuth> {
+            tokenRequestBuilder.setUsername(username).setPassword(password)
+        }
+        {{/hasOAuthMethods}}
+        return this
+    }
+
+    {{/isBasicBasic}}
+    {{^isBasicBasic}}
+    {{#hasOAuthMethods}}
+    fun setCredentials(username: String, password: String): ApiClient {
+        apiAuthorizations.values.runOnFirst<Interceptor, OAuth> {
+            tokenRequestBuilder.setUsername(username).setPassword(password)
+        }
+        return this
+    }
+    {{/hasOAuthMethods}}
+    {{/isBasicBasic}}
+    {{#isBasicBearer}}
+    fun setBearerToken(bearerToken: String): ApiClient {
+        apiAuthorizations.values.runOnFirst<Interceptor, HttpBearerAuth> {
+            this.bearerToken = bearerToken
+        }
+        return this
+    }
+
+    {{/isBasicBearer}}
+    {{/isBasic}}
+    {{/authMethods}}
+    {{/hasAuthMethods}}
+    {{#hasOAuthMethods}}
+    /**
+    * Helper method to configure the token endpoint of the first oauth found in the apiAuthorizations (there should be only one)
+    * @return Token request builder
+    */
+    fun getTokenEndPoint(): TokenRequestBuilder? {
+        var result: TokenRequestBuilder? = null
+        apiAuthorizations.values.runOnFirst<Interceptor, OAuth> {
+            result = tokenRequestBuilder
+        }
+        return result
+    }
+
+    /**
+    * Helper method to configure authorization endpoint of the first oauth found in the apiAuthorizations (there should be only one)
+    * @return Authentication request builder
+    */
+    fun getAuthorizationEndPoint(): AuthenticationRequestBuilder? {
+        var result: AuthenticationRequestBuilder? = null
+        apiAuthorizations.values.runOnFirst<Interceptor, OAuth> {
+            result = authenticationRequestBuilder
+        }
+        return result
+    }
+
+    /**
+    * Helper method to pre-set the oauth access token of the first oauth found in the apiAuthorizations (there should be only one)
+    * @param accessToken Access token
+    * @return ApiClient
+    */
+    fun setAccessToken(accessToken: String): ApiClient {
+        apiAuthorizations.values.runOnFirst<Interceptor, OAuth> {
+            setAccessToken(accessToken)
+        }
+        return this
+    }
+
+    /**
+    * Helper method to configure the oauth accessCode/implicit flow parameters
+    * @param clientId Client ID
+    * @param clientSecret Client secret
+    * @param redirectURI Redirect URI
+    * @return ApiClient
+    */
+    fun configureAuthorizationFlow(clientId: String, clientSecret: String, redirectURI: String): ApiClient {
+        apiAuthorizations.values.runOnFirst<Interceptor, OAuth> {
+            tokenRequestBuilder
+                .setClientId(clientId)
+                .setClientSecret(clientSecret)
+                .setRedirectURI(redirectURI)
+            authenticationRequestBuilder
+                ?.setClientId(clientId)
+                ?.setRedirectURI(redirectURI)
+        }
+        return this
+    }
+
+    /**
+    * Configures a listener which is notified when a new access token is received.
+    * @param accessTokenListener Access token listener
+    * @return ApiClient
+    */
+    fun registerAccessTokenListener(accessTokenListener: AccessTokenListener): ApiClient {
+        apiAuthorizations.values.runOnFirst<Interceptor, OAuth> {
+            registerAccessTokenListener(accessTokenListener)
+        }
+        return this
+    }
+
+    {{/hasOAuthMethods}}
+    /**
+     * Adds an authorization to be used by the client
+     * @param authName Authentication name
+     * @param authorization Authorization interceptor
+     * @return ApiClient
+     */
+    fun addAuthorization(authName: String, authorization: Interceptor): ApiClient {
+        if (apiAuthorizations.containsKey(authName)) {
+            throw RuntimeException("auth name $authName already in api authorizations")
+        }
+        apiAuthorizations[authName] = authorization
+        clientBuilder.addInterceptor(authorization)
+        return this
+    }
+
+    fun setLogger(logger: (String) -> Unit): ApiClient {
+        this.logger = logger
+        return this
+    }
+
+    fun <S> createService(serviceClass: Class<S>): S {
+        val usedCallFactory = this.callFactory ?: clientBuilder.build()
+        return retrofitBuilder.callFactory(usedCallFactory).build().create(serviceClass)
+    }
+
+    private fun normalizeBaseUrl() {
+        if (!baseUrl.endsWith("/")) {
+            baseUrl += "/"
+        }
+    }
+
+    private inline fun <T, reified U> Iterable<T>.runOnFirst(callback: U.() -> Unit) {
+        for (element in this) {
+            if (element is U)  {
+                callback.invoke(element)
+                break
+            }
+        }
+    }
+
+    companion object {
+        @JvmStatic
+        protected val baseUrlKey = "{{packageName}}.baseUrl"
+
+        @JvmStatic
+        val defaultBasePath: String by lazy {
+            System.getProperties().getProperty(baseUrlKey, "{{{basePath}}}")
+        }
+    }
+}

--- a/goodbye-service/build.gradle.kts
+++ b/goodbye-service/build.gradle.kts
@@ -58,7 +58,7 @@ tasks {
 }
 
 val taskDependencies = mapOf(
-    "spotlessKotlin" to listOf("compileKotlin", "processResources"),
+    "spotlessKotlin" to listOf("compileKotlin", "processResources", "compileTestKotlin", "test"),
 )
 
 taskDependencies.forEach {

--- a/hello-service/build.gradle.kts
+++ b/hello-service/build.gradle.kts
@@ -58,7 +58,7 @@ tasks {
 }
 
 val taskDependencies = mapOf(
-    "spotlessKotlin" to listOf("compileKotlin", "processResources"),
+    "spotlessKotlin" to listOf("compileKotlin", "processResources", "compileTestKotlin", "test"),
 )
 
 taskDependencies.forEach {


### PR DESCRIPTION
# Purpose

Nothing major was changed, but a few amendments have been made to the code:

- compile both on project and module level
- work correctly when calling the domain gateway
- remove dead code & comments
- Add HTTP collection for easier debugging

The OpenApi template for the clients can be removed after OpenApi generator version 7.3.0 is released with the same fix.

# Types of changes

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring

# Checklist

- [x] Documentation is updated
- [x] No new tests are needed
